### PR TITLE
Introduce a matrix with latest Ubuntu and macOS to test the build on macOS as well

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,7 +3,10 @@ on: [push, pull_request]
 jobs:
   check:
     name: Check
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/src/filters/array.ts
+++ b/src/filters/array.ts
@@ -88,3 +88,14 @@ export function uniq<T> (arr: T[]): T[] {
     return true
   })
 }
+
+export function sample<T> (v: T[] | string, count: number | undefined = undefined): T[] | string {
+  v = toValue(v)
+  if (isNil(v)) return []
+  if (!isArray(v)) {
+    v = stringify(v)
+    return [...v].sort(() => Math.random() ).slice(0, count).join('')
+  }
+
+  return [...v].sort(() => Math.random() ).slice(0, count)
+}


### PR DESCRIPTION
Once #615 is merged, the build script should work on macOS just as well as it does on Ubuntu and with this GitHub Actions matrix we can keep ensuring that it continues to work as it should.